### PR TITLE
fix(manifest): fix invalid match pattern of web_accessible_resources

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,7 +20,7 @@
   "web_accessible_resources": [
     {
       "resources": [ "/js/ui.js" ],
-      "matches": [ "https://figma.com/file/*", "https://www.figma.com/file/*" ]
+      "matches": [ "https://figma.com/*", "https://www.figma.com/*" ]
     }
   ]
 }


### PR DESCRIPTION
Hi @leadream

Currently, many developers have met this issue:
```text
Invalid value for 'web_accessible_resources[0]'. Invalid match pattern.
Could not load manifest.
```
Therefore, I looked through the Google Chrome Extension Manifest V3 documentation and found this specification:
![image](https://github.com/leadream/figma-viewer-chrome-plugin/assets/37981444/4e1824ac-c181-4b9d-82c0-6eeedf8b297e)

That's why I created this pull request. I hope this one could be helpful!
